### PR TITLE
Fix #7

### DIFF
--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/GitConventionalVersioning.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/GitConventionalVersioning.java
@@ -48,7 +48,11 @@ public class GitConventionalVersioning implements ConventionalVersioning
     @Override
     public SemanticVersion getNextVersion(SemanticVersion currentVersion) throws IOException, ScmApiException
     {
+        SemanticVersion nextVersion = currentVersion;
         SemanticVersionChange change = this.getNextVersionChangeType();
-        return currentVersion.nextVersion(change);
+        if (!SemanticVersionChange.PATCH.equals(change)) {
+            nextVersion = currentVersion.nextVersion(change);
+        }
+        return nextVersion;
     }
 }


### PR DESCRIPTION
This add a check to avoid the skipping of a version, by using nextVersion twice.
With the fix, we only change the patch version if it is not a patch, since the patch is bumped with the next development iteration.