### PR TITLE
fix!: cc style and release plugin fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,59 @@ with Java 1.8+ using Git for version control.
 
 ### Usage
 
-This plugin works together with the [Maven Release Plugin] to create 
+This plugin works together with the [Maven Release Plugin] to create
 conventional commit compliant releases for your Maven projects
 
 #### Install the Plugin
- 
+
 In your main `pom.xml` file add the plugin:
 
+```xml
     <plugins>
         <plugin>
             <groupId>com.smartling.cc4j</groupId>
             <artifactId>conventional-commits-maven-plugin</artifactId>
             <version>${version}</version>
         </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>3.0.0-M5</version>
+            <configuration>
+                <scmCommentPrefix>build(release): </scmCommentPrefix>
+                <scmDevelopmentCommitComment>ci(release): open next snapshot version</scmDevelopmentCommitComment>
+                <scmReleaseCommitComment>build(release): publish</scmReleaseCommitComment>
+            </configuration>
+        </plugin>
     </plugins>
+
+```
+
+In your CI code:
+
+- Execute only for master|main branch
+- skip builds for build(release) and ci(release) commits
+
+GitHub workflow:
+
+```yaml
+jobs:
+  main:
+    ...
+    if: |
+      "!contains(github.event.head_commit.message, 'build(release)')" &&
+      "!contains(github.event.head_commit.message, 'ci(release)')"
+```
+
+Gitlab:
+
+```yaml
+  only:
+    variables:
+      - '$CI_COMMIT_MESSAGE !~ /^(build|ci)\(release\):.+/'
+      - '$CI_COMMIT_BRANCH =~ /^(master|main)/'
+```
 
 #### Release a Version
 

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/Commit.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/Commit.java
@@ -6,8 +6,13 @@ import java.util.regex.Pattern;
 
 public class Commit
 {
-    private static final Pattern BREAKING_REGEX = Pattern.compile("^(fix|feat)!.+", Pattern.CASE_INSENSITIVE);
+    private static final Pattern BREAKING_REGEX = Pattern.compile(
+        "^((build|chore|ci|docs|fix|feat|refactor|style|test)[a-z0-9\\(\\)]*)((\\!([\\s]*:(.|\\n)*))|" +
+            "([\\s]*:(.|\\n)*(BREAKING(\\s|-)CHANGE)(.|\\n)*))", Pattern.CASE_INSENSITIVE);
 
+    private static final Pattern CONVENTIONAL_COMMIT_REGEX = Pattern.compile(
+        "^((build|chore|ci|docs|fix|feat|refactor|style|test)[a-z0-9\\(\\)]*)((\\!([\\s]*:" +
+            "(.|\\n)*))|([\\s]*:(.|\\n)*))", Pattern.CASE_INSENSITIVE);
     private final CommitAdapter commit;
 
     public Commit(CommitAdapter commit)
@@ -40,29 +45,22 @@ public class Commit
             return Optional.of(ConventionalCommitType.BREAKING_CHANGE);
         }
 
-        for (ConventionalCommitType cc : ConventionalCommitType.values())
+        if (CONVENTIONAL_COMMIT_REGEX.matcher(msg).matches())
         {
-            for (String t : cc.getCommitTypes())
-            {
-                if (msg.startsWith(t))
+            for (ConventionalCommitType cc : ConventionalCommitType.values()) {
+                if (ConventionalCommitType.BREAKING_CHANGE.equals(cc))
                 {
-                    type = cc;
-                    break;
+                    continue;
+                }
+
+                for (String t : cc.getCommitTypes()) {
+                    if (msg.startsWith(t)) {
+                        type = cc;
+                        break;
+                    }
                 }
             }
         }
-
-        // FIXME: check for breaking change in footer
-/*
-        for (FooterLine footerLine : commit.getFooterLines())
-        {
-            if (footerLine.getKey().equalsIgnoreCase(ConventionalCommitType.BREAKING_CHANGE.getCommitTypes().get(0))) {
-                type = ConventionalCommitType.BREAKING_CHANGE;
-                break;
-            }
-        }
-
- */
 
         return Optional.ofNullable(type);
     }

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/ConventionalCommitType.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/ConventionalCommitType.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public enum ConventionalCommitType implements Comparable<ConventionalCommitType>
 {
-    BREAKING_CHANGE(SemanticVersionChange.MAJOR, "breaking change", "!"),
+    BREAKING_CHANGE(SemanticVersionChange.MAJOR, "", "!"),
     BUILD(SemanticVersionChange.NONE, "build"),
     CHORE(SemanticVersionChange.MINOR, "chore"),
     CI(SemanticVersionChange.NONE, "ci"),
@@ -13,12 +13,13 @@ public enum ConventionalCommitType implements Comparable<ConventionalCommitType>
     FIX(SemanticVersionChange.PATCH, "fix"),
     FEAT(SemanticVersionChange.MINOR, "feat"),
     REFACTOR(SemanticVersionChange.MINOR, "refactor"),
+    STYLE(SemanticVersionChange.NONE, "style"),
     TEST(SemanticVersionChange.NONE, "test");
 
     private final List<String> commitTypes;
     private final SemanticVersionChange changeType;
 
-    ConventionalCommitType(SemanticVersionChange change, String... commitTypes)
+    ConventionalCommitType(final SemanticVersionChange change, final String... commitTypes)
     {
         this.commitTypes = Arrays.asList(commitTypes);
         this.changeType = change;

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/GitCommitAdapter.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/GitCommitAdapter.java
@@ -8,7 +8,7 @@ public class GitCommitAdapter implements CommitAdapter<RevCommit>
 {
     private final RevCommit commit;
 
-    GitCommitAdapter(RevCommit commit)
+    GitCommitAdapter(final RevCommit commit)
     {
         Objects.requireNonNull(commit, "commit cannot be null");
         this.commit = commit;

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/GitConventionalVersioning.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/GitConventionalVersioning.java
@@ -34,12 +34,12 @@ public class GitConventionalVersioning implements ConventionalVersioning
     {
         try
         {
-            Iterable<RevCommit> commits = logHandler().getCommitsSinceLastTag();
-            SemanticVersionChangeResolver resolver = semanticVersionChangeResolver();
+            final Iterable<RevCommit> commits = logHandler().getCommitsSinceLastTag();
+            final SemanticVersionChangeResolver resolver = semanticVersionChangeResolver();
 
             return resolver.resolveChange(commits);
         }
-        catch (GitAPIException e)
+        catch (final GitAPIException e)
         {
             throw new ScmApiException("Git operation failed", e);
         }
@@ -48,7 +48,7 @@ public class GitConventionalVersioning implements ConventionalVersioning
     @Override
     public SemanticVersion getNextVersion(SemanticVersion currentVersion) throws IOException, ScmApiException
     {
-        SemanticVersionChange change = this.getNextVersionChangeType();
+        final SemanticVersionChange change = this.getNextVersionChangeType();
         return currentVersion.nextVersion(change);
     }
 }

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/LogHandler.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/LogHandler.java
@@ -22,7 +22,7 @@ public class LogHandler
     private final Repository repository;
     private final Git git;
 
-    public LogHandler(Repository repository)
+    public LogHandler(final Repository repository)
     {
         Objects.requireNonNull(repository, "repository cannot be null");
         this.repository = repository;
@@ -31,10 +31,10 @@ public class LogHandler
 
     RevCommit getLastTaggedCommit() throws IOException, GitAPIException
     {
-        List<Ref> tags = git.tagList().call();
-        List<ObjectId> peeledTags = tags.stream().map(t -> repository.peel(t).getPeeledObjectId()).collect(Collectors.toList());
-        PlotWalk walk = new PlotWalk(repository);
-        RevCommit start = walk.parseCommit(repository.resolve("HEAD"));
+        final List<Ref> tags = git.tagList().call();
+        final List<ObjectId> peeledTags = tags.stream().map(t -> repository.peel(t).getPeeledObjectId()).collect(Collectors.toList());
+        final PlotWalk walk = new PlotWalk(repository);
+        final RevCommit start = walk.parseCommit(repository.resolve("HEAD"));
 
         walk.markStart(start);
 
@@ -55,8 +55,8 @@ public class LogHandler
 
     public Iterable<RevCommit> getCommitsSinceLastTag() throws IOException, GitAPIException
     {
-        ObjectId start = repository.resolve("HEAD");
-        RevCommit lastCommit = this.getLastTaggedCommit();
+        final ObjectId start = repository.resolve("HEAD");
+        final RevCommit lastCommit = this.getLastTaggedCommit();
 
         if (lastCommit == null)
         {

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/SemanticVersion.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/SemanticVersion.java
@@ -5,11 +5,13 @@ import java.util.Objects;
 
 public final class SemanticVersion
 {
+    public static final String VERSION_SUFFIX_SNAPSHOT = "-SNAPSHOT";
+
     private final Integer major;
     private final Integer minor;
     private final Integer patch;
 
-    public SemanticVersion(int major, int minor, int patch)
+    public SemanticVersion(final int major, final int minor, final int patch)
     {
         if (major < 0 || minor < 0 || patch < 0)
             throw new IllegalArgumentException("versions can only contain positive integers");
@@ -20,7 +22,7 @@ public final class SemanticVersion
     }
 
     @Override
-    public boolean equals(Object o)
+    public boolean equals(final Object o)
     {
         if (this == o)
         {
@@ -55,9 +57,9 @@ public final class SemanticVersion
         return patch;
     }
 
-    public SemanticVersion nextVersion(SemanticVersionChange change)
+    public SemanticVersion nextVersion(final SemanticVersionChange change)
     {
-        SemanticVersion nextVersion;
+        final SemanticVersion nextVersion;
 
         switch (change)
         {
@@ -68,8 +70,6 @@ public final class SemanticVersion
             nextVersion = new SemanticVersion(major, minor + 1, 0);
             break;
         case PATCH:
-            nextVersion = new SemanticVersion(major, minor, patch + 1);
-            break;
         case NONE:
             nextVersion = new SemanticVersion(major, minor, patch);
             break;
@@ -85,10 +85,10 @@ public final class SemanticVersion
         return toString(major, minor, patch);
     }
 
-    public static SemanticVersion parse(String version)
+    public static SemanticVersion parse(final String version)
     {
         Objects.requireNonNull(version, "version required");
-        String[] parts = version.split("\\.");
+        final String[] parts = version.replace(VERSION_SUFFIX_SNAPSHOT, "").split("\\.");
 
         if (parts.length != 3)
             throw new IllegalArgumentException("Invalid semantic version: " + version);
@@ -100,8 +100,13 @@ public final class SemanticVersion
         );
     }
 
-    private static String toString(int major, int minor, int patch)
+    private static String toString(final int major, final int minor, final int patch)
     {
         return String.format(Locale.US, "%d.%d.%d", major, minor, patch);
+    }
+
+    public String getDevelopmentVersionString()
+    {
+        return this.toString() + VERSION_SUFFIX_SNAPSHOT;
     }
 }

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/SimpleSemanticVersionChangeResolver.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/SimpleSemanticVersionChangeResolver.java
@@ -10,16 +10,16 @@ import java.util.Optional;
 public class SimpleSemanticVersionChangeResolver implements SemanticVersionChangeResolver
 {
     @Override
-    public SemanticVersionChange resolveChange(Iterable<RevCommit> commits)
+    public SemanticVersionChange resolveChange(final Iterable<RevCommit> commits)
     {
         Objects.requireNonNull(commits, "commits may not be null");
-        List<Commit> commitList = new ArrayList<>();
+        final List<Commit> commitList = new ArrayList<>();
         commits.iterator().forEachRemaining(c -> commitList.add(new Commit(new GitCommitAdapter(c))));
         SemanticVersionChange change = SemanticVersionChange.NONE;
 
-        for (Commit c : commitList)
+        for (final Commit c : commitList)
         {
-            Optional<ConventionalCommitType> commitType = c.getCommitType();
+            final Optional<ConventionalCommitType> commitType = c.getCommitType();
             if (commitType.isPresent())
             {
                 if (SemanticVersionChange.MAJOR.equals(commitType.get().getChangeType()))

--- a/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/scm/ScmApiException.java
+++ b/conventional-commits-common/src/main/java/com/smartling/cc4j/semantic/release/common/scm/ScmApiException.java
@@ -2,7 +2,7 @@ package com.smartling.cc4j.semantic.release.common.scm;
 
 public class ScmApiException extends Exception
 {
-    public ScmApiException(String message, Throwable cause)
+    public ScmApiException(final String message, final Throwable cause)
     {
         super(message, cause);
     }

--- a/conventional-commits-common/src/test/java/com/smartling/cc4j/semantic/release/common/CommitTest.java
+++ b/conventional-commits-common/src/test/java/com/smartling/cc4j/semantic/release/common/CommitTest.java
@@ -2,6 +2,8 @@ package com.smartling.cc4j.semantic.release.common;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.*;
 
 public class CommitTest
@@ -20,36 +22,60 @@ public class CommitTest
     @Test
     public void getCommitTypeBreakingChange()
     {
-        assertEquals(ConventionalCommitType.BREAKING_CHANGE, create("breaking change: new version").getCommitType().get());
-        assertEquals(ConventionalCommitType.BREAKING_CHANGE, create("Breaking Change: add foo").getCommitType().get());
-        assertEquals(ConventionalCommitType.BREAKING_CHANGE, create("BREAKING CHANGE(scope): add foo").getCommitType().get());
+        assertFalse(create("breaking change: new version").getCommitType().isPresent());
+        assertFalse(create("Breaking Change: add foo").getCommitType().isPresent());
+        assertFalse(create("BREAKING CHANGE(scope): add foo").getCommitType().isPresent());
     }
 
     @Test
     public void getCommitTypeBreakingChangeExclamation()
     {
-        assertEquals(ConventionalCommitType.BREAKING_CHANGE, create("fix!: new version").getCommitType().get());
-        assertEquals(ConventionalCommitType.BREAKING_CHANGE, create("feat!: new version").getCommitType().get());
-        assertEquals(ConventionalCommitType.TEST, create("test!: new version").getCommitType().get());
+        final Optional<ConventionalCommitType> ctFix = create("fix!: new version").getCommitType();
+        assertTrue(ctFix.isPresent());
+        assertEquals(ConventionalCommitType.BREAKING_CHANGE, ctFix.get());
+
+        final Optional<ConventionalCommitType> ctFeatBreaking = create("feat!: new version").getCommitType();
+        assertTrue(ctFeatBreaking.isPresent());
+        assertEquals(ConventionalCommitType.BREAKING_CHANGE, ctFeatBreaking.get());
+
+        final Optional<ConventionalCommitType> ctTestBreaking = create("test!: new version").getCommitType();
+        assertTrue(ctTestBreaking.isPresent());
+        assertEquals(ConventionalCommitType.BREAKING_CHANGE, ctTestBreaking.get());
     }
 
     @Test
     public void getCommitTypeFeat()
     {
-        assertEquals(ConventionalCommitType.FEAT, create("feat: add foo").getCommitType().get());
-        assertEquals(ConventionalCommitType.FEAT, create("Feat: add foo").getCommitType().get());
-        assertEquals(ConventionalCommitType.FEAT, create("feat(scope): add foo").getCommitType().get());
+        final Optional<ConventionalCommitType> ctFeat = create("feat: add foo").getCommitType();
+        assertTrue(ctFeat.isPresent());
+        assertEquals(ConventionalCommitType.FEAT, ctFeat.get());
+
+        final Optional<ConventionalCommitType> ctFeat2 = create("Feat: add foo").getCommitType();
+        assertTrue(ctFeat2.isPresent());
+        assertEquals(ConventionalCommitType.FEAT, ctFeat2.get());
+
+        final Optional<ConventionalCommitType> ctFeat3 = create("feat(scope): add foo").getCommitType();
+        assertTrue(ctFeat3.isPresent());
+        assertEquals(ConventionalCommitType.FEAT, ctFeat3.get());
     }
 
     @Test
     public void getCommitTypeFix()
     {
-        assertEquals(ConventionalCommitType.FIX, create("fix: foo").getCommitType().get());
-        assertEquals(ConventionalCommitType.FIX, create("Fix: foo").getCommitType().get());
-        assertEquals(ConventionalCommitType.FIX, create("fix(scope): foo").getCommitType().get());
+        final Optional<ConventionalCommitType> ctFix = create("fix: foo").getCommitType();
+        assertTrue(ctFix.isPresent());
+        assertEquals(ConventionalCommitType.FIX, ctFix.get());
+
+        final Optional<ConventionalCommitType> ctFix2 = create("Fix: foo").getCommitType();
+        assertTrue(ctFix2.isPresent());
+        assertEquals(ConventionalCommitType.FIX, ctFix2.get());
+
+        final Optional<ConventionalCommitType> ctFix3 = create("fix(scope): foo").getCommitType();
+        assertTrue(ctFix3.isPresent());
+        assertEquals(ConventionalCommitType.FIX, ctFix3.get());
     }
 
-    static Commit create(String shortMessage)
+    static Commit create(final String shortMessage)
     {
         return new Commit(new DummyCommitAdapter(shortMessage));
     }

--- a/conventional-commits-common/src/test/java/com/smartling/cc4j/semantic/release/common/LogHandlerTest.java
+++ b/conventional-commits-common/src/test/java/com/smartling/cc4j/semantic/release/common/LogHandlerTest.java
@@ -47,7 +47,7 @@ public class LogHandlerTest {
     }
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown()
     {
         //Files.delete(tempDir);
     }

--- a/conventional-commits-common/src/test/java/com/smartling/cc4j/semantic/release/common/SemanticVersionTest.java
+++ b/conventional-commits-common/src/test/java/com/smartling/cc4j/semantic/release/common/SemanticVersionTest.java
@@ -23,8 +23,8 @@ public class SemanticVersionTest
     @Test
     public void nextVersionPatch()
     {
-        SemanticVersion next = SemanticVersion.parse("9.10.11").nextVersion(SemanticVersionChange.PATCH);
-        assertEquals(new SemanticVersion(9, 10, 12), next);
+        SemanticVersion next = SemanticVersion.parse("9.10.11-SNAPSHOT").nextVersion(SemanticVersionChange.PATCH);
+        assertEquals(new SemanticVersion(9, 10, 11), next);
     }
 
     @Test

--- a/conventional-commits-maven-plugin/pom.xml
+++ b/conventional-commits-maven-plugin/pom.xml
@@ -54,13 +54,13 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -148,7 +148,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.2</version>
                         <configuration>
                             <debug>true</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>

--- a/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersionChangeValidatorMojo.java
+++ b/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersionChangeValidatorMojo.java
@@ -19,15 +19,15 @@ public class ConventionalVersionChangeValidatorMojo extends AbstractVersioningMo
     {
         try
         {
-            ConventionalVersioning versioning = this.getConventionalVersioning();
-            SemanticVersionChange change = versioning.getNextVersionChangeType();
+            final ConventionalVersioning versioning = this.getConventionalVersioning();
+            final SemanticVersionChange change = versioning.getNextVersionChangeType();
 
             if (SemanticVersionChange.NONE.equals(change))
             {
                 throw new NoVersionChangeException("No conventional commit version change to release");
             }
         }
-        catch (IOException | ScmApiException e)
+        catch (final IOException | ScmApiException e)
         {
             throw new MojoExecutionException("Unable to access repository", e);
         }

--- a/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersioningMojo.java
+++ b/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersioningMojo.java
@@ -8,9 +8,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.Properties;
 
@@ -24,21 +24,22 @@ public class ConventionalVersioningMojo extends AbstractVersioningMojo
     {
         try
         {
-            Properties props = this.createReleaseProperties();
+            final Properties props = this.createReleaseProperties();
 
-            session.getExecutionProperties().putAll(props);
+            session.getUserProperties().putAll(props);
             writeVersionFile(props);
-            getLog().warn(String.format(Locale.US, "Set release properties: %s", props));
+
+            getLog().info(String.format(Locale.US, "Set release properties: %s", props));
         }
-        catch (IOException | ScmApiException e)
+        catch (final IOException | ScmApiException e)
         {
             throw new MojoExecutionException("SCM error: " + e.getMessage(), e);
         }
     }
 
-    private void writeVersionFile(Properties props) throws MojoExecutionException
+    private void writeVersionFile(final Properties props) throws MojoExecutionException
     {
-        File f = outputDirectory;
+        final File f = outputDirectory;
 
         if (!f.exists())
         {
@@ -47,11 +48,11 @@ public class ConventionalVersioningMojo extends AbstractVersioningMojo
 
         File touch = new File(f, "version.props");
 
-        try (OutputStream out = new FileOutputStream(touch))
+        try (OutputStream out = Files.newOutputStream(touch.toPath()))
         {
             props.store(out, "");
         }
-        catch (IOException e)
+        catch (final IOException e)
         {
             throw new MojoExecutionException("Error creating file " + touch, e);
         }

--- a/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/context/MavenConventionalVersioning.java
+++ b/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/context/MavenConventionalVersioning.java
@@ -10,7 +10,7 @@ public class MavenConventionalVersioning
 {
     private final Repository repository;
 
-    public MavenConventionalVersioning(Repository repository)
+    public MavenConventionalVersioning(final Repository repository)
     {
         Objects.requireNonNull(repository, "repository required");
         this.repository = repository;

--- a/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/context/NoVersionChangeException.java
+++ b/conventional-commits-maven-plugin/src/main/java/com/smartling/cc4j/semantic/plugin/maven/context/NoVersionChangeException.java
@@ -4,7 +4,7 @@ import org.apache.maven.plugin.MojoFailureException;
 
 public class NoVersionChangeException extends MojoFailureException
 {
-    public NoVersionChangeException(String message)
+    public NoVersionChangeException(final String message)
     {
         super(message);
     }

--- a/conventional-commits-maven-plugin/src/test/java/com/smartling/cc4j/semantic/plugin/maven/AbstractScmMojoTest.java
+++ b/conventional-commits-maven-plugin/src/test/java/com/smartling/cc4j/semantic/plugin/maven/AbstractScmMojoTest.java
@@ -24,8 +24,8 @@ public class AbstractScmMojoTest
     @Before
     public void setUp() throws Exception
     {
-        Path tempDir = Files.createTempDirectory("convention-commits-version-change-mojo-test");
-        Path sourceProjectPath = Paths.get("target/test-classes/project-to-test/pom.xml");
+        final Path tempDir = Files.createTempDirectory("convention-commits-version-change-mojo-test");
+        final Path sourceProjectPath = Paths.get("target/test-classes/project-to-test/pom.xml");
         Files.copy(sourceProjectPath, tempDir.resolve("pom.xml"));
 
         this.repository = new RepositoryBuilder().setWorkTree(tempDir.toFile()).build();
@@ -42,8 +42,8 @@ public class AbstractScmMojoTest
 
     void createCommit(String commitMessage) throws IOException, GitAPIException
     {
-        String filename = String.format(Locale.US, "%s.txt", UUID.randomUUID().toString());
-        BufferedWriter writer = new BufferedWriter(new FileWriter(projectPath.resolve(filename).toFile()));
+        final String filename = String.format(Locale.US, "%s.txt", UUID.randomUUID());
+        final BufferedWriter writer = new BufferedWriter(new FileWriter(projectPath.resolve(filename).toFile()));
         writer.write("Hello world");
         writer.newLine();
         writer.close();

--- a/conventional-commits-maven-plugin/src/test/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersionChangeValidatorMojoTest.java
+++ b/conventional-commits-maven-plugin/src/test/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersionChangeValidatorMojoTest.java
@@ -1,12 +1,14 @@
 package com.smartling.cc4j.semantic.plugin.maven;
 
 import com.smartling.cc4j.semantic.plugin.maven.context.NoVersionChangeException;
+import com.smartling.cc4j.semantic.release.common.SemanticVersion;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -16,7 +18,7 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
     public MojoRule rule = new MojoRule()
     {
         @Override
-        protected void before() throws Throwable
+        protected void before()
         {
         }
 
@@ -28,7 +30,7 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
 
     ConventionalVersionChangeValidatorMojo getMojo() throws Exception
     {
-        File pom = projectPath.toFile();
+        final File pom = projectPath.toFile();
         assertNotNull(pom);
         assertTrue(pom.exists());
 
@@ -41,14 +43,14 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
     @Test(expected = NoVersionChangeException.class)
     public void executeNoConventionalCommits() throws Exception
     {
-        ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
         myMojo.execute();
     }
 
     @Test(expected = NoVersionChangeException.class)
     public void executeNoConventionalVersionChangeCommits() throws Exception
     {
-        ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
         createCommit("ci: release x.y.z");
         myMojo.execute();
     }
@@ -56,7 +58,7 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
     @Test
     public void executeChoreCommit() throws Exception
     {
-        ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
         createCommit("chore: add something");
         myMojo.execute();
     }
@@ -64,7 +66,7 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
     @Test
     public void executeFeatCommit() throws Exception
     {
-        ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
         createCommit("feat: add foo");
         myMojo.execute();
     }
@@ -72,7 +74,7 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
     @Test
     public void executeFixCommit() throws Exception
     {
-        ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
         createCommit("fix: add something");
         myMojo.execute();
     }
@@ -80,8 +82,119 @@ public class ConventionalVersionChangeValidatorMojoTest extends AbstractScmMojoT
     @Test
     public void executeBreakingChangeCommit() throws Exception
     {
-        ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
         createCommit("fix: add something");
         myMojo.execute();
+    }
+
+    @Test
+    public void executeMultipleChangesOnlyPatch() throws Exception
+    {
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        createCommit("fix: add something");
+        createCommit("fix: add something");
+        createCommit("docs: shiny docs added");
+        myMojo.execute();
+
+        final SemanticVersion originalVersion = SemanticVersion.parse(myMojo.getOriginalVersion());
+
+        assertNotNull(myMojo.getOriginalVersion());
+        assertTrue(myMojo.getOriginalVersion().endsWith(SemanticVersion.VERSION_SUFFIX_SNAPSHOT));
+
+        assertEquals(originalVersion.getMajor(), myMojo.getNextVersion().getMajor());
+        assertEquals(originalVersion.getMinor(), myMojo.getNextVersion().getMinor());
+        assertEquals(originalVersion.getPatch(), myMojo.getNextVersion().getPatch());
+    }
+
+    @Test
+    public void executeMultipleChangesMinorAndPatch() throws Exception
+    {
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        createCommit("fix: add something");
+        createCommit("chore: add something");
+        createCommit("docs: shiny docs added");
+        myMojo.execute();
+
+        final SemanticVersion originalVersion = SemanticVersion.parse(myMojo.getOriginalVersion());
+
+        assertEquals(originalVersion.getMajor(), myMojo.getNextVersion().getMajor());
+        assertEquals(originalVersion.getMinor() + 1, myMojo.getNextVersion().getMinor());
+        assertEquals(0, myMojo.getNextVersion().getPatch());
+    }
+
+    @Test
+    public void executeMultipleChangesMinorAndPatchWithBreakingChange() throws Exception
+    {
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        createCommit("fix: add something");
+        createCommit("chore: add something");
+        createCommit("fix!: add some breaking thing");
+        createCommit("docs: shiny docs added");
+        myMojo.execute();
+
+        final SemanticVersion originalVersion = SemanticVersion.parse(myMojo.getOriginalVersion());
+
+        assertEquals(originalVersion.getMajor() + 1, myMojo.getNextVersion().getMajor());
+        assertEquals(0 , myMojo.getNextVersion().getMinor());
+        assertEquals(0, myMojo.getNextVersion().getPatch());
+    }
+
+    @Test
+    public void executeMultipleChangesMinorAndPatchWithBreakingChangeInFooter() throws Exception
+    {
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        createCommit("fix: add something");
+        createCommit("chore: add something");
+        createCommit("fix: add some breaking thing." +
+            "With a long, long, long description." +
+            "BREAKING CHANGE: this rocks.");
+        createCommit("docs: shiny docs added");
+        myMojo.execute();
+
+        final SemanticVersion originalVersion = SemanticVersion.parse(myMojo.getOriginalVersion());
+
+        assertEquals(originalVersion.getMajor() + 1, myMojo.getNextVersion().getMajor());
+        assertEquals(0 , myMojo.getNextVersion().getMinor());
+        assertEquals(0, myMojo.getNextVersion().getPatch());
+    }
+
+    @Test
+    public void executeMultipleChangesMinorAndPatchWithNonCompliantCommit() throws Exception
+    {
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        createCommit("fix: add something");
+        createCommit("chore: add something");
+        createCommit("fix: add some breaking thing." +
+            "With a long, long, long description." +
+            "BREAKING CHANGE: this rocks.");
+        createCommit("choke add something");
+        createCommit("docs: shiny docs added");
+        myMojo.execute();
+
+        final SemanticVersion originalVersion = SemanticVersion.parse(myMojo.getOriginalVersion());
+
+        assertEquals(originalVersion.getMajor() + 1, myMojo.getNextVersion().getMajor());
+        assertEquals(0 , myMojo.getNextVersion().getMinor());
+        assertEquals(0, myMojo.getNextVersion().getPatch());
+    }
+
+    @Test(expected = NoVersionChangeException.class)
+    public void executeMultipleChangesWithOnlyNonCompliantCommit() throws Exception
+    {
+        final ConventionalVersionChangeValidatorMojo myMojo = getMojo();
+        createCommit("fixx add something");
+        createCommit("chores add something");
+        createCommit("fiks add some breaking thing." +
+            "With a long, long, long description." +
+            "BREAKING CHANGE: this rocks.");
+        createCommit("choke add something");
+        createCommit("docs shiny docs added");
+        myMojo.execute();
+
+        final SemanticVersion originalVersion = SemanticVersion.parse(myMojo.getOriginalVersion());
+
+        assertEquals(originalVersion.getMajor(), myMojo.getNextVersion().getMajor());
+        assertEquals(0, myMojo.getNextVersion().getMinor());
+        assertEquals(0, myMojo.getNextVersion().getPatch());
     }
 }

--- a/conventional-commits-maven-plugin/src/test/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersioningMojoTest.java
+++ b/conventional-commits-maven-plugin/src/test/java/com/smartling/cc4j/semantic/plugin/maven/ConventionalVersioningMojoTest.java
@@ -15,7 +15,7 @@ public class ConventionalVersioningMojoTest extends AbstractScmMojoTest
     @Rule public MojoRule rule = new MojoRule()
     {
         @Override
-        protected void before() throws Throwable
+        protected void before()
         {
         }
 
@@ -31,19 +31,19 @@ public class ConventionalVersioningMojoTest extends AbstractScmMojoTest
     @Test
     public void testExecute() throws Exception
     {
-        File pom = projectPath.toFile();
+        final File pom = projectPath.toFile();
         assertNotNull(pom);
         assertTrue(pom.exists());
 
-        ConventionalVersioningMojo myMojo = (ConventionalVersioningMojo) rule.lookupConfiguredMojo(pom, "version");
+        final ConventionalVersioningMojo myMojo = (ConventionalVersioningMojo) rule.lookupConfiguredMojo(pom, "version");
         assertNotNull(myMojo);
         myMojo.execute();
 
-        File outputDirectory = (File) rule.getVariableValueFromObject(myMojo, "outputDirectory");
+        final File outputDirectory = (File) rule.getVariableValueFromObject(myMojo, "outputDirectory");
         assertNotNull(outputDirectory);
         assertTrue(outputDirectory.exists());
 
-        File touch = new File(outputDirectory, "version.props");
+        final File touch = new File(outputDirectory, "version.props");
         assertTrue(touch.exists());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,29 +33,29 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.5.0.201909110433-r</version>
+            <version>6.1.0.202203080745-r</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.28</version>
+            <version>1.7.36</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <dryRun>false</dryRun>
@@ -131,7 +131,7 @@
                     <plugin>
                         <groupId>com.smartling.cc4j</groupId>
                         <artifactId>conventional-commits-maven-plugin</artifactId>
-                        <version>0.1.0</version>
+                        <version>0.2.0</version>
                         <inherited>false</inherited>
                         <executions>
                             <execution>


### PR DESCRIPTION
Fixes 
- maven-release-plugin issues that the calculated properties are not taken and tag version is reverted in the snapshot commit
- breaking change pattern
- patch version skips as mentioned in #7
- "breaking change" type was not compliant to the cc styles
- cc style check added 

Test cases added to check the versioning behaviour in case multiple commit types.

Dependency lib bumps where possible. 